### PR TITLE
Add command array to AmbigiousCommandInvocationError

### DIFF
--- a/Remora.Commands/Results/AmbiguousCommandInvocationError.cs
+++ b/Remora.Commands/Results/AmbiguousCommandInvocationError.cs
@@ -20,7 +20,9 @@
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+using System.Collections.Generic;
 using JetBrains.Annotations;
+using Remora.Commands.Services;
 using Remora.Results;
 
 namespace Remora.Commands.Results
@@ -28,7 +30,8 @@ namespace Remora.Commands.Results
     /// <summary>
     /// Raised when two or more commands pass all preconditions and are otherwise acceptable as execution candidates.
     /// </summary>
+    /// <param name="CommandCandidates">The potential commands that could have been executed.</param>
     [PublicAPI]
-    public record AmbiguousCommandInvocationError()
+    public record AmbiguousCommandInvocationError(IReadOnlyList<PreparedCommand> CommandCandidates)
         : ResultError("Two or more commands could have been executed by that.");
 }

--- a/Remora.Commands/Services/CommandService.cs
+++ b/Remora.Commands/Services/CommandService.cs
@@ -379,7 +379,12 @@ namespace Remora.Commands.Services
             // Then, check if we have to bail out at this point
             if (preparedCommands.Count(r => r.IsSuccess) > 1)
             {
-                return new AmbiguousCommandInvocationError();
+                var ambiguousCommands = preparedCommands
+                    .Where(r => r.IsSuccess)
+                    .Select(r => r.Entity)
+                    .ToArray();
+
+                return new AmbiguousCommandInvocationError(ambiguousCommands);
             }
 
             if (preparedCommands.Any(r => r.IsSuccess))


### PR DESCRIPTION
This PR adds an array of ambiguous commands to the AmbigiousCommandInvocationError, which allows for recovering from this non-fatal error by optionally attempting to execute one of the commands based on some predicate (e.g. slash command).

This is, in Remora.Commands/Remora.Discord.Commands' current state, only useful if someone has a custom command handler, but it could also serve to be useful when debugging, as the commmand names/parameters can be displayed in a debugger or even in a log, instead of just a cryptic "Two or more commands could have been executed by that."